### PR TITLE
Credential update for Function call

### DIFF
--- a/autonomous_database/vector_search/vector_search.md
+++ b/autonomous_database/vector_search/vector_search.md
@@ -656,7 +656,7 @@ You can load your own PDFs into Object Storage if you like.  If you would like t
 	end;
 
 	v_resp := dbms_cloud.send_request(
-	credential_name => v_ociapi_credential,
+	credential_name => v_vector_credential,
 	uri => v_gen_ai_endpoint || v_chat_endpoint,
 	method => dbms_cloud.method_post,
 	body => utl_raw.cast_to_raw(json_object(


### PR DESCRIPTION
I think we need the vector credential here to complete the call successfully to the cohere.command-r-plus /20231130/actions/chat api call. Otherwise when you execute the queries later it failed on my side. 